### PR TITLE
Remove www from the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 In an effort to learn es6 and [redux](https://github.com/rackt/redux), this is SoundRedux, a simple [Soundcloud](http://soundcloud.com) client
 
-See it in action at http://www.soundredux.io
+See it in action at http://soundredux.io
 
 Todo: use [normalizr](https://github.com/gaearon/normalizr) for less data duplication
 


### PR DESCRIPTION
I'm not sure why, but http://www.soundredux.io doesn't work for me.
http://soundredux.io does.