### PR TITLE
Add electron dependency and setup main module to launch app in a window.

### DIFF
--- a/desktop/index.js
+++ b/desktop/index.js
@@ -1,5 +1,6 @@
 import app from 'app';
 import BrowserWindow from 'browser-window';
+import globalShortcut from 'global-shortcut';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -33,4 +34,16 @@ app.on('ready', () => {
     // when you should delete the corresponding element.
     mainWindow = null;
   });
+
+  globalShortcut.register('MediaNextTrack', () => {
+    mainWindow.webContents.executeJavaScript('Player.nextSong()');
+  });
+
+  globalShortcut.register('MediaPreviousTrack', () => {
+    mainWindow.webContents.executeJavaScript('Player.prevSong()');
+  });
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -1,0 +1,36 @@
+var app = require('app');
+var BrowserWindow = require('browser-window');
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+var mainWindow = null;
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform != 'darwin') {
+    app.quit();
+  }
+});
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+app.on('ready', function() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 600});
+
+  // Load app from webpack dev server.
+  mainWindow.loadUrl('http://localhost:8080');
+
+  // Open the DevTools.
+  mainWindow.openDevTools();
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function() {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  });
+});

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -24,7 +24,7 @@ app.on('ready', () => {
   mainWindow.maximize();
 
   // Load app from webpack dev server.
-  mainWindow.loadUrl('http://localhost:8080');
+  mainWindow.loadURL('http://localhost:8080');
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -19,13 +19,12 @@ app.on('window-all-closed', () => {
 // initialization and is ready to create browser windows.
 app.on('ready', () => {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600});
+  mainWindow = new BrowserWindow({});
+
+  mainWindow.maximize();
 
   // Load app from webpack dev server.
   mainWindow.loadUrl('http://localhost:8080');
-
-  // Open the DevTools.
-  mainWindow.openDevTools();
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -41,6 +41,10 @@ app.on('ready', () => {
   globalShortcut.register('MediaPreviousTrack', () => {
     mainWindow.webContents.executeJavaScript('Player.prevSong()');
   });
+
+  globalShortcut.register('MediaPlayPause', () => {
+    mainWindow.webContents.executeJavaScript('Player.togglePlay()');
+  });
 });
 
 app.on('will-quit', () => {

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -1,12 +1,12 @@
-var app = require('app');
-var BrowserWindow = require('browser-window');
+import app from 'app';
+import BrowserWindow from 'browser-window';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function() {
+app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform != 'darwin') {
@@ -16,7 +16,7 @@ app.on('window-all-closed', function() {
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
-app.on('ready', function() {
+app.on('ready', () => {
   // Create the browser window.
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
@@ -27,7 +27,7 @@ app.on('ready', function() {
   mainWindow.openDevTools();
 
   // Emitted when the window is closed.
-  mainWindow.on('closed', function() {
+  mainWindow.on('closed', () => {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
     "css-loader": "^0.18.0",
-    "electron-prebuilt": "^0.34.0",
+    "electron-prebuilt": "^0.35.0",
     "expect": "^1.12.2",
     "extract-text-webpack-plugin": "^0.8.2",
     "isomorphic-fetch": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "webpack-dev-server --progress --colors --hot --content-base ./server/public --config ./webpack.config.js",
     "test": "mocha --compilers js:babel-core/register --recursive",
     "prebuild": "sed -i.bak \"s/'.*'/'${SOUND_REDUX_PROD:-f4323c6f7c0cd73d2d786a2b1cdae80c}'/\" ./scripts/constants/Config.js",
-    "postbuild": "sed -i.bak \"s/'.*'/'${SOUND_REDUX_DEV:-f4323c6f7c0cd73d2d786a2b1cdae80c}'/\" ./scripts/constants/Config.js && rm ./scripts/constants/Config.js.bak"
+    "postbuild": "sed -i.bak \"s/'.*'/'${SOUND_REDUX_DEV:-f4323c6f7c0cd73d2d786a2b1cdae80c}'/\" ./scripts/constants/Config.js && rm ./scripts/constants/Config.js.bak",
+    "desktop": "electron desktop"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
     "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
     "css-loader": "^0.18.0",
+    "electron-prebuilt": "^0.34.0",
     "expect": "^1.12.2",
     "extract-text-webpack-plugin": "^0.8.2",
     "isomorphic-fetch": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha --compilers js:babel-core/register --recursive",
     "prebuild": "sed -i.bak \"s/'.*'/'${SOUND_REDUX_PROD:-f4323c6f7c0cd73d2d786a2b1cdae80c}'/\" ./scripts/constants/Config.js",
     "postbuild": "sed -i.bak \"s/'.*'/'${SOUND_REDUX_DEV:-f4323c6f7c0cd73d2d786a2b1cdae80c}'/\" ./scripts/constants/Config.js && rm ./scripts/constants/Config.js.bak",
-    "desktop": "electron desktop"
+    "desktop": "electron -r babel/register desktop"
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/andrewngu/sound-redux",
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
+    "babel": "^5.8.23",
     "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
     "css-loader": "^0.18.0",

--- a/scripts/components/Player.js
+++ b/scripts/components/Player.js
@@ -57,12 +57,17 @@ class Player extends Component {
         audioElement.addEventListener('play', this.handlePlay, false);
         audioElement.addEventListener('timeupdate', this.handleTimeUpdate, false);
         audioElement.addEventListener('volumechange', this.handleVolumeChange, false);
-        audioElement.play();
+        if (this.props.player.isPlaying) {
+            audioElement.play();
+        }
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.playingSongId && prevProps.playingSongId === this.props.playingSongId) {
-            return;
+    componentDidUpdate() {
+        const audioElement = React.findDOMNode(this.refs.audio);
+        if (this.props.player.isPlaying) {
+            audioElement.play();
+        } else {
+            audioElement.pause();
         }
 
         ReactDOM.findDOMNode(this.refs.audio).play();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import App from './containers/App';
 import configureStore from './store/configureStore';
+import {changeSong} from './actions/player';
+import {CHANGE_TYPES} from './constants/SongConstants';
 
 require('../styles/main.scss');
 
@@ -15,3 +17,15 @@ ReactDOM.render(
     </Provider>,
     document.getElementById('main')
 );
+
+// Expose a global API for controlling the player.
+// Used for example by the Electron Desktop wrapper for media key bindings.
+window.Player = {
+  nextSong() {
+    store.dispatch(changeSong(CHANGE_TYPES.NEXT));
+  },
+
+  prevSong() {
+    store.dispatch(changeSong(CHANGE_TYPES.PREV));
+  }
+};

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import App from './containers/App';
 import configureStore from './store/configureStore';
-import {changeSong} from './actions/player';
+import {changeSong, toggleIsPlay} from './actions/player';
 import {CHANGE_TYPES} from './constants/SongConstants';
 
 require('../styles/main.scss');
@@ -27,5 +27,10 @@ window.Player = {
 
   prevSong() {
     store.dispatch(changeSong(CHANGE_TYPES.PREV));
+  },
+
+  togglePlay() {
+    const {player: {isPlaying}} = store.getState();
+    store.dispatch(togglePlay(isPlaying));
   }
 };

--- a/scripts/reducers/player.js
+++ b/scripts/reducers/player.js
@@ -16,7 +16,8 @@ export default function player(state = initialState, action) {
 
     case types.CHANGE_PLAYING_SONG:
         return Object.assign({}, state, {
-            currentSongIndex: action.songIndex
+            currentSongIndex: action.songIndex,
+            isPlaying: true
         });
 
     case types.CHANGE_SELECTED_PLAYLISTS:


### PR DESCRIPTION
Right now it just loads the app from the webpack dev server.
To launch the app once webpack dev is running execute `npm run desktop`.

**Work in-progress**
- [x] Change songs with media keys (next or previous)
- [x] Pause or play current song with media key
- [ ] Get production build working for desktop distribution.
- [ ] Fix issue with API requests being handled as file jobs. Intercept using protocol module.
  - https://github.com/atom/electron/issues/1793
- [ ] Authentication with SoundCloud
- [ ] Package up the app for distribution (electron-packager?)
