### PR TITLE
Remove unused action imports from navigator action file

### DIFF
--- a/scripts/actions/navigator.js
+++ b/scripts/actions/navigator.js
@@ -1,5 +1,3 @@
-import {changeActiveSong} from '../actions/songs';
-import {changeActiveUser} from '../actions/users';
 import * as types from '../constants/ActionTypes';
 import {constructUrl, parseUrl} from '../utils/RouteUtils';
 


### PR DESCRIPTION
These two imports are also unused in the navigator actions file, I suppose.

