### PR TITLE
Remove isomorphic-fetch import from playlist actions file

### DIFF
--- a/scripts/actions/playlists.js
+++ b/scripts/actions/playlists.js
@@ -1,4 +1,3 @@
-import fetch from 'isomorphic-fetch';
 import {arrayOf, normalize} from 'normalizr';
 import {changePlayingSong} from '../actions/player';
 import * as types from '../constants/ActionTypes';


### PR DESCRIPTION
As other actions are not relying on isomorphic-fetch, remove import from playlists action.