### PR TITLE
Add local server install/run info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,17 @@ Uses [normalizr](https://github.com/gaearon/normalizr)
 2. `npm run start`
 3. visit `http://localhost:8080`
 
+### Install local server
+
+To see user authentication in action in your local environment, install and run the server.
+
+1. Make sure you have [Go](https://golang.org/) installed.
+2. Make sure the `sound-redux` folder is in your `$GOPATH`
+3. `$ cd server`
+4. `$ go get .`
+5. `$ go install .`
+
+Once installed you can run the server:
+`$ server`
+
 Feedback, issues, etc. are more than welcome!


### PR DESCRIPTION
We have a small frontend team studying sound-redux, and they were going to get an email with reminders about local server installation and running.

So I thought it might help more people if it was in the README.

If you think this is a good idea but the execution needs improvement, I’ll be more than happy to tweak it.