### PR TITLE
CSS break-word on comment item

### DIFF
--- a/styles/custom/components/comment.scss
+++ b/styles/custom/components/comment.scss
@@ -33,6 +33,8 @@
 .comment-comment {
     overflow: hidden;
     text-overflow: ellipsis;
+    word-break: break-word;
+    word-wrap: break-word;
 }
 
 .comment-time {


### PR DESCRIPTION
A specific type of comment's text content is breaking the comments box.

I randomly stumbled across this:
![comment](http://i.imgur.com/qI5fcSVl.png)

ref: https://soundredux.io/#/songs/121239554