### PR TITLE
some player's volume fixes

### DIFF
--- a/scripts/components/Player.js
+++ b/scripts/components/Player.js
@@ -70,6 +70,7 @@ class Player extends Component {
     audioElement.addEventListener('play', this.handlePlay, false);
     audioElement.addEventListener('timeupdate', this.handleTimeUpdate, false);
     audioElement.addEventListener('volumechange', this.handleVolumeChange, false);
+    audioElement.volume = this.state.volume
     audioElement.play();
   }
 

--- a/scripts/components/Player.js
+++ b/scripts/components/Player.js
@@ -248,9 +248,8 @@ class Player extends Component {
 
     this.setState({
       isSeeking: false,
-    }, () => {
-      ReactDOM.findDOMNode(this.refs.audio).volume = this.state.volume;
     });
+    LocalStorageUtils.set('volume', this.state.volume);
   }
 
   handleKeyDown(e) {


### PR DESCRIPTION
1. Set volume when player has been initialised.
2. Stop dragging volume's slider not fired **volumechange** event  due volume actually doesn't change since last **mousemove** event.