### PR TITLE
CSS tweaks on `body`

### DIFF
--- a/styles/custom/components/type.scss
+++ b/styles/custom/components/type.scss
@@ -1,6 +1,7 @@
 body {
     color: #222;
-    font-family: 'Open Sans';
+    font-family: 'Open Sans', sans-serif';
     font-size: 14px;
     background-color: #f4f4f4;
+    overflow-y: scroll;
 }


### PR DESCRIPTION
- Scrollbar appears permanently; stops the screen shaking around on windows when content length changes.
- Sans-serif fallback for body font; if Open Sans times out or otherwise doesn't work, everything won't be Times New Roman now.