### PR TITLE
Issue #24: Load new songs if playing last of already loaded songs

### DIFF
--- a/scripts/components/Player.js
+++ b/scripts/components/Player.js
@@ -9,6 +9,7 @@ import { formatSeconds, formatStreamUrl } from '../utils/FormatUtils';
 import { offsetLeft } from '../utils/MouseUtils';
 import { getImageUrl } from '../utils/SongUtils';
 import LocalStorageUtils from '../utils/LocalStorageUtils';
+import { fetchSongsIfNeeded } from '../actions/PlaylistsActions';
 
 const propTypes = {
   dispatch: PropTypes.func.isRequired,
@@ -18,6 +19,7 @@ const propTypes = {
   song: PropTypes.object,
   songs: PropTypes.object.isRequired,
   users: PropTypes.object.isRequired,
+  playlist: PropTypes.string,
 };
 
 class Player extends Component {
@@ -72,6 +74,16 @@ class Player extends Component {
     audioElement.addEventListener('volumechange', this.handleVolumeChange, false);
     audioElement.volume = this.state.volume;
     audioElement.play();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { dispatch, playingSongId, playlist, playlists, player } = nextProps;
+    const switchedFromOtherSong = this.props.playingSongId !== playingSongId;
+    const startedWithLastSong = this.props.player.isPlaying === false && player.isPlaying === true;
+    if (playingSongId && !this.state.shuffle && (switchedFromOtherSong || startedWithLastSong)
+      && playlists[playlist].items.length === player.currentSongIndex + 1) {
+      dispatch(fetchSongsIfNeeded(playlist));
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/scripts/containers/PlayerContainer.js
+++ b/scripts/containers/PlayerContainer.js
@@ -27,17 +27,24 @@ class PlayerContainer extends Component {
 PlayerContainer.propTypes = propTypes;
 
 function mapStateToProps(state) {
-  const { entities, environment, player, playlists } = state;
+  const { entities, environment, player, playlists, navigator } = state;
   const { isMobile } = environment;
   const { songs, users } = entities;
+  const { query } = navigator.route;
   const playingSongId = getPlayingSongId(player, playlists);
 
+  const time = query && query.t ? query.t : null;
+  let playlist = query && query.q ? query.q : 'house';
+  if (time) {
+    playlist = `${playlist} - ${time}`;
+  }
   return {
     isMobile,
     player,
     playingSongId,
     playlists,
     songs,
+    playlist,
     users,
   };
 }


### PR DESCRIPTION
Previously if you were at the end of the loaded songs for a specific
playlist it would stop, but now it loads the songs automatically
if you start playing the last loaded song. This holds true unless
"shuffle" is selected.