### PR TITLE
fix(song-list-item): remove the overflow

### DIFF
--- a/styles/custom/components/song-list-item.scss
+++ b/styles/custom/components/song-list-item.scss
@@ -29,7 +29,6 @@
 .song-list-item__info__wrap {
   margin: 10px 20px 0 0;
   flex: 1;
-  overflow: hidden;
 }
 
 .song-list-item__info {


### PR DESCRIPTION
When we click to like a song, the popover is hidden by the overflow of his parent.

![sound-redux](https://cloud.githubusercontent.com/assets/1011503/22905391/5dca8334-f240-11e6-89d7-46c390a7c7c9.PNG)

