### PR TITLE
Fixed Redux link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SoundRedux
 
-In an effort to learn es6 and [redux](https://github.com/rackt/redux), this is SoundRedux, a simple [Soundcloud](http://soundcloud.com) client
+In an effort to learn es6 and [redux](https://github.com/reactjs/redux), this is SoundRedux, a simple [Soundcloud](http://soundcloud.com) client
 
 See it in action at https://soundredux.io
 


### PR DESCRIPTION
It was set to "https://github.com/rackt/redux", which is not Redux that is used in the project.
Replaced with "https://github.com/reactjs/redux"