### PR TITLE
Start using callback refs

### DIFF
--- a/scripts/components/MobileInfiniteScroll.js
+++ b/scripts/components/MobileInfiniteScroll.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 
 const propTypes = {
   children: PropTypes.node,
@@ -15,17 +14,17 @@ class MobileInfiniteScroll extends Component {
   }
 
   componentDidMount() {
-    const el = ReactDOM.findDOMNode(this.refs.scroll);
+    const el = this.scroll;
     el.addEventListener('scroll', this.onScroll, false);
   }
 
   componentWillUnmount() {
-    const el = ReactDOM.findDOMNode(this.refs.scroll);
+    const el = this.scroll;
     el.removeEventListener('scroll', this.onScroll, false);
   }
 
   onScroll() {
-    const el = ReactDOM.findDOMNode(this.refs.scroll);
+    const el = this.scroll;
     if (el.scrollTop >= (el.scrollHeight - el.offsetHeight - 200)) {
       this.props.dispatch(this.props.scrollFunc());
     }
@@ -33,7 +32,10 @@ class MobileInfiniteScroll extends Component {
 
   render() {
     return (
-      <div className={this.props.className} ref="scroll">
+      <div
+        className={this.props.className}
+        ref={(node) => { this.scroll = node; }}
+      >
         {this.props.children}
       </div>
     );

--- a/scripts/components/MobilePlayerContent.js
+++ b/scripts/components/MobilePlayerContent.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 import { changeCurrentTime, changeSong, toggleIsPlaying } from '../actions/PlayerActions';
 import { CHANGE_TYPES, IMAGE_SIZES } from '../constants/SongConstants';
 import { formatSongTitle, formatStreamUrl } from '../utils/FormatUtils';
@@ -34,7 +33,7 @@ class MobilePlayerContent extends Component {
   }
 
   componentDidMount() {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     audioElement.addEventListener('ended', this.handleEnded, false);
     audioElement.addEventListener('loadedmetadata', this.handleLoadedMetadata, false);
     audioElement.addEventListener('loadstart', this.handleLoadStart, false);
@@ -49,11 +48,11 @@ class MobilePlayerContent extends Component {
       return;
     }
 
-    ReactDOM.findDOMNode(this.refs.audio).play();
+    this.audio.play();
   }
 
   componentWillUnmount() {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     audioElement.removeEventListener('ended', this.handleEnded, false);
     audioElement.removeEventListener('loadedmetadata', this.handleLoadedMetadata, false);
     audioElement.removeEventListener('loadstart', this.handleLoadStart, false);
@@ -73,7 +72,7 @@ class MobilePlayerContent extends Component {
 
   handleEnded() {
     if (this.state.repeat) {
-      ReactDOM.findDOMNode(this.refs.audio).play();
+      this.audio.play();
     } else if (this.state.shuffle) {
       this.changeSong(CHANGE_TYPES.SHUFFLE);
     } else {
@@ -82,7 +81,7 @@ class MobilePlayerContent extends Component {
   }
 
   handleLoadedMetadata() {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     this.setState({
       duration: Math.floor(audioElement.duration),
     });
@@ -121,7 +120,7 @@ class MobilePlayerContent extends Component {
   togglePlay(e) {
     e.preventDefault();
     const { isPlaying } = this.props.player;
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     if (isPlaying) {
       audioElement.pause();
     } else {
@@ -157,7 +156,12 @@ class MobilePlayerContent extends Component {
 
     return (
       <div className="mobile-player" style={{ backgroundImage: `url(${image})` }}>
-        <audio id="audio" ref="audio" src={formatStreamUrl(song.stream_url)}></audio>
+        <audio
+          id="audio"
+          ref={(node) => { this.audio = node; }}
+          src={formatStreamUrl(song.stream_url)}
+        >
+        </audio>
         <div className="mobile-player-bg" />
         <div className="mobile-player-extras" />
         <div className="mobile-player-content fade-in">

--- a/scripts/components/NavSearch.js
+++ b/scripts/components/NavSearch.js
@@ -36,7 +36,7 @@ class NavSearch extends Component {
     const isInsideInput = e.target.tagName.toLowerCase().match(/input|textarea/);
     if (keyCode === 47 && !isInsideInput) {
       e.preventDefault();
-      ReactDOM.findDOMNode(this.refs.query).focus();
+      this.query.focus();
     }
   }
 
@@ -45,7 +45,7 @@ class NavSearch extends Component {
       <div className="nav-search">
         <i className="icon ion-search" />
         <input
-          ref="query"
+          ref={(node) => { this.query = node; }}
           className="nav-search-input"
           placeholder="SEARCH"
           onKeyPress={this.handleOnKeyPress}

--- a/scripts/components/Player.js
+++ b/scripts/components/Player.js
@@ -62,7 +62,7 @@ class Player extends Component {
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyDown);
 
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     audioElement.addEventListener('ended', this.handleEnded, false);
     audioElement.addEventListener('loadedmetadata', this.handleLoadedMetadata, false);
     audioElement.addEventListener('loadstart', this.handleLoadStart, false);
@@ -79,13 +79,13 @@ class Player extends Component {
       return;
     }
 
-    ReactDOM.findDOMNode(this.refs.audio).play();
+    this.audio.play();
   }
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyDown, false);
 
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     audioElement.removeEventListener('ended', this.handleEnded, false);
     audioElement.removeEventListener('loadedmetadata', this.handleLoadedMetadata, false);
     audioElement.removeEventListener('loadstart', this.handleLoadStart, false);
@@ -111,14 +111,14 @@ class Player extends Component {
   }
 
   changeVolume(e) {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     const volume = (e.clientX - offsetLeft(e.currentTarget)) / e.currentTarget.offsetWidth;
     audioElement.volume = volume;
   }
 
   handleEnded() {
     if (this.state.repeat) {
-      ReactDOM.findDOMNode(this.refs.audio).play();
+      this.audio.play();
     } else if (this.state.shuffle) {
       this.changeSong(CHANGE_TYPES.SHUFFLE);
     } else {
@@ -127,7 +127,7 @@ class Player extends Component {
   }
 
   handleLoadedMetadata() {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     this.setState({
       duration: Math.floor(audioElement.duration),
     });
@@ -165,7 +165,7 @@ class Player extends Component {
 
   handleSeekMouseMove(e) {
     const { dispatch } = this.props;
-    const seekBar = ReactDOM.findDOMNode(this.refs.seekBar);
+    const seekBar = this.seekBar;
     const diff = e.clientX - offsetLeft(seekBar);
     const pos = diff < 0 ? 0 : diff;
     let percent = pos / seekBar.offsetWidth;
@@ -186,7 +186,7 @@ class Player extends Component {
     this.setState({
       isSeeking: false,
     }, () => {
-      ReactDOM.findDOMNode(this.refs.audio).currentTime = currentTime;
+      this.audio.currentTime = currentTime;
     });
   }
 
@@ -226,7 +226,7 @@ class Player extends Component {
   }
 
   handleVolumeMouseMove(e) {
-    const volumeBar = ReactDOM.findDOMNode(this.refs.volumeBar);
+    const volumeBar = this.volumeBar;
     const diff = e.clientX - offsetLeft(volumeBar);
     const pos = diff < 0 ? 0 : diff;
     let percent = pos / volumeBar.offsetWidth;
@@ -235,7 +235,7 @@ class Player extends Component {
     this.setState({
       volume: percent,
     });
-    ReactDOM.findDOMNode(this.refs.audio).volume = percent;
+    this.audio.volume = percent;
   }
 
   handleVolumeMouseUp() {
@@ -273,7 +273,7 @@ class Player extends Component {
 
   seek(e) {
     const { dispatch } = this.props;
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     const percent = (e.clientX - offsetLeft(e.currentTarget)) / e.currentTarget.offsetWidth;
     const currentTime = Math.floor(percent * this.state.duration);
 
@@ -282,7 +282,7 @@ class Player extends Component {
   }
 
   toggleMute() {
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     if (this.state.muted) {
       audioElement.muted = false;
     } else {
@@ -294,7 +294,7 @@ class Player extends Component {
 
   togglePlay() {
     const { isPlaying } = this.props.player;
-    const audioElement = ReactDOM.findDOMNode(this.refs.audio);
+    const audioElement = this.audio;
     if (isPlaying) {
       audioElement.pause();
     } else {
@@ -403,7 +403,11 @@ class Player extends Component {
 
     return (
       <div className="player">
-        <audio id="audio" ref="audio" src={formatStreamUrl(song.stream_url)} />
+        <audio
+          id="audio"
+          ref={(node) => { this.audio = node; }}
+          src={formatStreamUrl(song.stream_url)}
+        />
         <div className="container">
           <div className="player-main">
             <div className="player-section player-info">
@@ -442,7 +446,7 @@ class Player extends Component {
             </div>
             <div className="player-section player-seek">
               <div className="player-seek-bar-wrap" onClick={this.seek}>
-                <div className="player-seek-bar" ref="seekBar">
+                <div className="player-seek-bar" ref={(node) => { this.seekBar = node; }}>
                   {this.renderDurationBar()}
                 </div>
               </div>
@@ -479,7 +483,7 @@ class Player extends Component {
               </div>
               <div className="player-volume">
                 <div className="player-seek-bar-wrap" onClick={this.changeVolume}>
-                  <div className="player-seek-bar" ref="volumeBar">
+                  <div className="player-seek-bar" ref={(node) => { this.volumeBar = node; }}>
                     {this.renderVolumeBar()}
                   </div>
                 </div>

--- a/scripts/components/Popover.js
+++ b/scripts/components/Popover.js
@@ -32,14 +32,13 @@ class Popover extends Component {
       return;
     }
 
-    const node = ReactDOM.findDOMNode(this.refs.popover);
+    const node = this.popover;
 
     if (!node.contains(e.target)) {
       this.setState({
-         isOpen: false
-      })
+        isOpen: false,
+      });
     }
-
   }
 
   toggleIsOpen() {
@@ -52,7 +51,7 @@ class Popover extends Component {
 
     return (
       <div
-        ref="popover"
+        ref={(node) => { this.popover = node; }}
         className={`${className} popover ${(isOpen ? ' open' : '')}`}
         onClick={this.toggleIsOpen}
       >

--- a/scripts/components/Waveform.js
+++ b/scripts/components/Waveform.js
@@ -117,7 +117,7 @@ class Waveform extends Component {
   render() {
     return (
       <div className="waveform">
-        <canvas className="waveform-canvas" ref="canvas"></canvas>
+        <canvas className="waveform-canvas"></canvas>
         {this.renderWaveform()}
       </div>
     );


### PR DESCRIPTION
Hello. 
I noticed there were some string refs so I went ahead and replaced them with callback refs. Apparently it's considered good practice: [Legacy API: String Refs](https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs).
And it looks like you don't have to use ReactDOM.findDOMNode with refs. 