### PR TITLE
Fix runtime exception that prevented MobileNav from rendering

### DIFF
--- a/scripts/components/MobileNav.js
+++ b/scripts/components/MobileNav.js
@@ -219,7 +219,7 @@ class MobileNav extends Component {
     return (
       <div className="mobile-nav">
         {this.renderGenreMenu(isGenreMenuOpen, playlist)}
-        {this.renderUserMenu(isUserMenuOpen, playlist, getPlaylistDetails)}
+        {this.renderUserMenu(isUserMenuOpen, getPlaylistDetails)}
         {this.renderGenresOptions(isGenreMenuOpen, playlist)}
         {this.renderUserOptions()}
       </div>


### PR DESCRIPTION
It errored with something like "Cannot convert undefined or null to object at Function.from (native)..." which made the mobile client basically unusable. 